### PR TITLE
Change primary language name to "MDX"

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
       {
         "id": "mdx",
         "aliases": [
-          "Markdown React",
           "MDX",
+          "Markdown React",
           "mdx"
         ],
         "extensions": [

--- a/syntaxes/mdx.tmLanguage.json
+++ b/syntaxes/mdx.tmLanguage.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-  "name": "Markdown React",
+  "name": "MDX",
   "patterns": [
     { "include": "#jsx" },
     { "include": "#markdown" }


### PR DESCRIPTION
Why is the primary language name added by this extension "Markdown React" instead of "MDX"? I can't find the phrase "markdown react" anywhere on the [MDX website](https://mdxjs.com/) or [in their GitHub repo](https://github.com/mdx-js/mdx/search?p=2&q=%22markdown+react%22).

This isn't a big deal or anything, especially since the language ID is still "mdx"—I just find it a bit jarring every time I see "Markdown React" down in the status bar of my editor.

Thanks again for this handy extension!