### PR TITLE
Now highlights js expressions embedded in jsx

### DIFF
--- a/syntaxes/mdx.tmLanguage.json
+++ b/syntaxes/mdx.tmLanguage.json
@@ -9,7 +9,8 @@
     "jsx": {
       "patterns": [
         { "include": "#jsx-module" },
-        { "include": "#jsx-tag" }
+        { "include": "#jsx-tag" },
+        { "include": "#jsx-evaluated-code"}
       ],
       "repository": {
         "jsx-module": {
@@ -29,6 +30,18 @@
             {
               "begin": "^(?=<([a-z]|[A-Z]))",
               "end": "(?<=>)",
+              "contentName": "source.js.jsx",
+              "patterns": [
+                { "include": "source.js.jsx" }
+              ]
+            }
+          ]
+        },
+        "jsx-evaluated-code": {
+          "patterns": [
+            {
+              "begin": "(?!```$){",
+              "end": "}",
               "contentName": "source.js.jsx",
               "patterns": [
                 { "include": "source.js.jsx" }

--- a/test/fixture.mdx
+++ b/test/fixture.mdx
@@ -1,4 +1,5 @@
 import Component from './component'
+import {anImportedFunction} from './someFile'
 
 export const meta = {
   title: 'Blog Post',
@@ -23,3 +24,5 @@ Lorem ipsum dolor sit amet, consectetur adipiscing **elit**. Ut ac lobortis <b>v
 ## Subtitle
 
 Lorem ipsum dolor sit _amet_, consectetur adipiscing elit. Ut ac lobortis velit.
+
+{anImportedFunction('Here is some JS code', 2) ?? 'text'}


### PR DESCRIPTION
In JSX, you can include JS expressions within tags, like:
```
<ATag>
{doSomething(‘a’, 7)}
</asdfadf
```

This PR adds syntax highlighting for those expressions.

### Limitations
It will still highlight JS that isn’t an expression (eg. a class definition), which as far as I can tell is a limitation of how embedded languages work in TextMare syntax highlighting definitions.